### PR TITLE
fix tdpm on linux

### DIFF
--- a/nodes/nodes_ode.py
+++ b/nodes/nodes_ode.py
@@ -1,4 +1,3 @@
-import dis
 import sys
 import comfy
 import torch

--- a/nodes/nodes_ode.py
+++ b/nodes/nodes_ode.py
@@ -1,3 +1,5 @@
+import dis
+import sys
 import comfy
 import torch
 import torchdiffeq
@@ -25,14 +27,18 @@ class ODEFunction:
                 desc="solve",
                 unit="%",
                 leave=False,
-                position=1
+                position=1,
+                file=sys.stdout,
+                disable=True
             )
         else:
             self.pbar = tqdm(
                 total=n_steps,
                 desc="solve",
                 leave=False,
-                position=1
+                position=1,
+                file=sys.stdout,
+                disable=True
             )
 
     def __call__(self, t, y):


### PR DESCRIPTION
Colorama interferes with tdpm on Linux.  A working fix for both platforms is to disable tdpm auto-wrapping itself in colorama and explicitly set the output pipe to stdout.

```
comfyui     | AttributeError: 'NoneType' object has no attribute 'cursor_adjust'
comfyui     | AttributeError: 'tqdm_asyncio' object has no attribute 'last_print_t'
```

This PR fixes the crash on Linux, while maintaining functionality in Windows if colorama is installed.